### PR TITLE
Ensure reaped builds do not tally disk usage.

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -140,6 +140,11 @@ class Api {
 
     self.db.getProjectDiskTotal(projectId)
       .then(function(result) {
+        // Zero is returned as an empty object rather than a proper number if
+        // we don't convert it to a string.   :-(
+        if (result === 0) {
+          result = '0';
+        }
         res.send(result);
         next();
       })

--- a/lib/Db.js
+++ b/lib/Db.js
@@ -56,11 +56,14 @@ class Db {
       .select('projectId')
       .sum('bytesReal')
       .from('build')
-      .where({'projectId': projectId})
+      .where({'projectId': projectId, 'reaped': false})
       .groupBy('projectId')
       .first()
       .then(function(result) {
-        return result.sum;
+        // If there are no active builds we don't get a result. This effectivly
+        // means they are using zero bytes.
+        let total = (result && result.sum) ? result.sum : 0;
+        return total;
       });
   }
 

--- a/seeds/builds_seed.js
+++ b/seeds/builds_seed.js
@@ -44,7 +44,10 @@ exports.seed = function(knex, Promise) {
         createEntry({branchName: 'secondBranch', prName: 'secondPr', reaped: false}),
         createEntry({branchName: 'thirdBranch', prName: 'thirdPr', reaped: false}),
         createEntry({branchName: 'fourthBranch', prName: 'fourthPr', reaped: false, projectId: 'c01f0f8c-9774-43e7-b717-5ca78bd44c01'}),
-        createEntry({branchName: 'fifthBranch', prName: 'fifthPr', reaped: false, projectId: 'c01f0f8c-9774-43e7-b717-5ca78bd44c01'})
+        createEntry({branchName: 'fifthBranch', prName: 'fifthPr', reaped: false, projectId: 'c01f0f8c-9774-43e7-b717-5ca78bd44c01'}),
+        createEntry({branchName: 'branch6', prName: 'pr6', reaped: true, projectId: 'c01f0f8c-9774-43e7-b717-5ca78bd44c01'}),
+        createEntry({branchName: 'branch7', prName: 'pr7', reaped: true, projectId: '5140b34e-21ed-4395-85bf-f3bda5adaa14'}),
+        createEntry({branchName: 'branch8', prName: 'pr8', reaped: true, projectId: '5140b34e-21ed-4395-85bf-f3bda5adaa14'}),
       ]);
     });
 };

--- a/test/api.js
+++ b/test/api.js
@@ -16,6 +16,7 @@ const db = new Db({knex});
 
 const projectId = 'c01f0f8c-9774-43e7-b717-5ca78bd44c01';
 const buildId = 'edae5055-db9e-4ae4-8863-7561cb6e0aa2';
+const reapedProjectId = '5140b34e-21ed-4395-85bf-f3bda5adaa14';
 
 const logger = {
   info: function() {return},
@@ -74,7 +75,7 @@ describe('API', function() {
     request.get(`http://localhost:${apiPort}/project`, function(error, response, body) {
       response.statusCode.should.equal(200);
       let data = JSON.parse(response.body);
-      data.length.should.equal(4);
+      data.length.should.equal(5);
       body.should.containEql(projectId);
       done(error);
     });
@@ -90,11 +91,20 @@ describe('API', function() {
     });
   });
 
+  it('returns the number zero for project disk usage if all builds are reaped', function(done) {
+    request.get(`http://localhost:${apiPort}/project/${reapedProjectId}/disk-usage`, function(error, response, body) {
+      response.statusCode.should.equal(200);
+      let data = JSON.parse(response.body);
+      data.should.equal('0');
+      done(error);
+    });
+  });
+
   it('returns an array of builds', function(done) {
     request.get(`http://localhost:${apiPort}/build/`, function(error, response, body) {
       response.statusCode.should.equal(200);
       let data = JSON.parse(response.body);
-      data.length.should.equal(5);
+      data.length.should.equal(8);
       body.should.containEql(buildId);
       done(error);
     });

--- a/test/db.js
+++ b/test/db.js
@@ -75,7 +75,7 @@ describe('DB', function() {
       db.getBuilds()
         .then(function(result) {
           // This data comes from the seed file.
-          should.equal(5, result.length);
+          should.equal(8, result.length);
           done();
         });
     });
@@ -84,7 +84,7 @@ describe('DB', function() {
       db.getProjects()
         .then(function(result) {
           // This data comes from the seed file.
-          should.equal(4, result.length);
+          should.equal(5, result.length);
           done();
         });
     });


### PR DESCRIPTION
When calculating the disk usage for a project, we don't want to
factor in reaped builds. We also want to ensure that valid zeros
are returned if the project doesn't use any disk space. These
changes allow these two important cases. Tests are updated to
ensure these conditions are true.